### PR TITLE
Let Vim detect markdown (vim74/filetype.vim)

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,3 +1,3 @@
-" markdown filetype file
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}   set filetype=markdown
+" Markdown filetype file
+au BufNewFile,BufRead *.md set filetype=markdown
 au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx,tmp,old} set filetype=markdown


### PR DESCRIPTION
Removed `ftdetect/markdown.vim`, and let Vim detect markdown on its own, at `/usr/share/vim74/filetype.vim`.